### PR TITLE
Implement MediaStreamAudioSourceNode (using getUserMedia, example included)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ cache/
 *.swp
 elm-stuff
 elm.js
+UserMedia.elm
+Native/UserMedia.js

--- a/Native/WebAudio.js
+++ b/Native/WebAudio.js
@@ -433,7 +433,7 @@ Elm.Native.WebAudio.make = function(elm) {
   values.createDynamicsCompressorNode = function(context) {
     var node = extractContext(context).createDynamicsCompressor();
     var ret = buildAudioNode(node);
-    buildAudioParam('threshold', 'treshold', ret);
+    buildAudioParam('threshold', 'threshold', ret);
     buildAudioParam('knee', 'knee', ret);
     buildAudioParam('ratio', 'ratio', ret);
     buildAudioParam('reduction', 'reduction', ret);

--- a/Native/WebAudio.js
+++ b/Native/WebAudio.js
@@ -498,6 +498,12 @@ Elm.Native.WebAudio.make = function(elm) {
   };
 
 
+  /* MediaStreamAudioSourceNode */
+  values.createMediaStreamAudioSourceNode = F2(function(context, source) {
+      var node = extractContext(context).createMediaStreamSource(source);
+      return buildAudioNode(node);
+  });
+
 
   /* OscillatorNode */
   function setOscillatorWaveType(type, node) {

--- a/WebAudio.elm
+++ b/WebAudio.elm
@@ -724,8 +724,8 @@ pauseMediaElement = Native.WebAudio.pauseMediaElement
 
 type alias MediaStreamAudioSourceNode = AudioNode {}
 
-createMediaStreamSourceNode : AudioContext -> MediaStream -> MediaStreamAudioSourceNode
-createMediaStreamSourceNode = Native.WebAudio.createMediaStreamSourceNode
+createMediaStreamAudioSourceNode : AudioContext -> MediaStream -> MediaStreamAudioSourceNode
+createMediaStreamAudioSourceNode = Native.WebAudio.createMediaStreamAudioSourceNode
 
 
 {- TODO: Type of a MediaStreamAudioDestinationNode -}

--- a/WebAudio.elm
+++ b/WebAudio.elm
@@ -184,7 +184,7 @@ These nodes are currently unimplemented.
 -}
 
 import Native.WebAudio
-
+import UserMedia exposing (MediaStream)
 
 
 {-| The AudioContext
@@ -722,8 +722,13 @@ pauseMediaElement = Native.WebAudio.pauseMediaElement
 
 
 
+type alias MediaStreamAudioSourceNode = AudioNode {}
+
+createMediaStreamSourceNode : AudioContext -> MediaStream -> MediaStreamAudioSourceNode
+createMediaStreamSourceNode = Native.WebAudio.createMediaStreamSourceNode
+
+
 {- TODO: Type of a MediaStreamAudioDestinationNode -}
-{- TODO: Type of a MediaStreamAudioSourceNode -}
 
 
 

--- a/elm-package.json
+++ b/elm-package.json
@@ -3,13 +3,16 @@
     "summary": "Elm library for accessing the Web Audio API",
     "repository": "https://github.com/bmatcuk/elm-webaudio.git",
     "license": "BSD3",
-    "native-modules": true,
     "source-directories": [
         "."
     ],
-    "exposed-modules": ["WebAudio"],
+    "exposed-modules": [
+        "WebAudio"
+    ],
+    "native-modules": true,
     "dependencies": {
-        "elm-lang/core": "2.0.1 <= v < 3.0.0"
+        "elm-lang/core": "2.0.1 <= v < 3.0.0",
+        "evancz/elm-html": "3.0.0 <= v < 4.0.0"
     },
     "elm-version": "0.15.0 <= v < 0.16.0"
 }

--- a/examples/Stream.elm
+++ b/examples/Stream.elm
@@ -1,0 +1,30 @@
+import UserMedia exposing (MediaStream, requestUserMedia)
+import WebAudio exposing (..)
+import Task as T
+import Signal as S exposing ((<~))
+import Html exposing (div, text)
+
+view model =
+    case model of
+        Nothing -> div [] [ text "Nothing" ]
+        Just stream ->
+            -- I would expect this to immediately feed me back the microphone input
+            let node = createMediaStreamSourceNode DefaultContext stream
+                        |> connectNodes (getDestinationNode DefaultContext) 0 0
+            in
+               div [] [ text "Got user media" ]
+
+{-| send one time request for usermedia, stream is then forwarded to the
+    mailbox
+-}
+port getUserMedia : T.Task x ()
+port getUserMedia =
+        requestUserMedia userMediaStream.address { audio=True, video=False }
+
+userMediaStream : S.Mailbox (Maybe MediaStream)
+userMediaStream =
+    S.mailbox Nothing
+
+
+main =
+    view <~ userMediaStream.signal

--- a/examples/Stream.elm
+++ b/examples/Stream.elm
@@ -8,11 +8,10 @@ view model =
     case model of
         Nothing -> div [] [ text "Nothing" ]
         Just stream ->
-            -- I would expect this to immediately feed me back the microphone input
-            let node = createMediaStreamSourceNode DefaultContext stream
+            let node = createMediaStreamAudioSourceNode DefaultContext stream
                         |> connectNodes (getDestinationNode DefaultContext) 0 0
             in
-               div [] [ text "Got user media" ]
+               div [] [ text ("Got user media : " ++ (.label stream)) ]
 
 {-| send one time request for usermedia, stream is then forwarded to the
     mailbox


### PR DESCRIPTION
See #3 for more details. This is a proposal to how one might connect Elm and live microphone input. The implementation depends on [elm-usermedia](https://github.com/giraj/elm-usermedia), a wrapper around `getUserMedia`. 
